### PR TITLE
feat: add optional file OCR for chat

### DIFF
--- a/API/app/routers/chat.py
+++ b/API/app/routers/chat.py
@@ -1,13 +1,15 @@
 # app/routers/chat.py
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, UploadFile, File, Form
 from pydantic import BaseModel
 from typing import List, Optional
-# from sqlalchemy.ext.asyncio import AysncSession
+import json
 
 from app.services.stage import prepare_llm_request
 from app.services.llm_gateway import call_llm
+from app.services.common import Mode
+from app.services.ocr import ocr_file
 
-# from app.crud import chatCRUD 
+# from app.crud import chatCRUD
 from app.models.userModel import User
 # from app.database import get_db
 
@@ -24,9 +26,20 @@ class AskBody(BaseModel):
     first_message: bool = False
     attachment_ids: Optional[List[str]] = None  # 업로드된 file_id 배열
 
+    @classmethod
+    def as_form(
+        cls,
+        text: str = Form(...),
+        first_message: bool = Form(False),
+        attachment_ids: Optional[str] = Form(None),
+    ) -> "AskBody":
+        ids = json.loads(attachment_ids) if attachment_ids else None
+        return cls(text=text, first_message=first_message, attachment_ids=ids)
+
 @router.post("/ask")
 async def ask(
-    body: AskBody,
+    body: AskBody = Depends(AskBody.as_form),
+    file: UploadFile | None = File(None),
     current_user: UserRead = Depends(deps.get_current_user),
     # db: AsyncSession = Depends(get_db)
 ):
@@ -47,6 +60,11 @@ async def ask(
             "mode": llm_req["mode"],
             "used_attachments": llm_req["attachments_used"],
         }
+
+    if file is not None and llm_req["mode"] in (Mode.TERMS, Mode.REFUND):
+        ocr_text = await ocr_file(file)
+        print(f"[ROUTER] OCR extracted {len(ocr_text)} chars")
+        # TODO: OpenSearch ingest pipeline integration
 
     # 3단계: LLM 호출
     answer = await call_llm(llm_req["messages"])

--- a/API/app/services/ocr.py
+++ b/API/app/services/ocr.py
@@ -1,0 +1,42 @@
+import base64
+import mimetypes
+import os
+
+from fastapi import UploadFile
+from openai import AsyncOpenAI
+
+client = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+
+async def ocr_file(file: UploadFile) -> str:
+    data = await file.read()
+    mime, _ = mimetypes.guess_type(file.filename)
+    if mime is None:
+        mime = "application/octet-stream"
+
+    if mime == "application/pdf":
+        import fitz  # PyMuPDF
+
+        text = []
+        with fitz.open(stream=data, filetype="pdf") as doc:
+            for page in doc:
+                text.append(page.get_text())
+        return "".join(text)
+
+    if mime.startswith("image/"):
+        b64 = base64.b64encode(data).decode("utf-8")
+        resp = await client.responses.create(
+            model="gpt-4o-mini",
+            input=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": "Extract text from this document."},
+                        {"type": "input_image", "image": {"base64": b64, "mime_type": mime}},
+                    ],
+                }
+            ],
+        )
+        return getattr(resp, "output_text", "")
+
+    return ""

--- a/API/requirements.txt
+++ b/API/requirements.txt
@@ -17,3 +17,4 @@ python-jose[cryptography]>=3.3.0
 passlib[bcrypt]>=1.7.4
 
 openai==1.99.6
+PyMuPDF==1.26.3


### PR DESCRIPTION
## Summary
- allow optional file upload in chat/ask and convert multipart form
- run GPT-4o mini OCR for image files and PyMuPDF for PDFs in TERMS or REFUND mode
- add OCR helper service and PyMuPDF dependency

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689c8d860014832386848f17a50a50e0