### PR TITLE
Run LLM calls in background threads

### DIFF
--- a/API/app/services/llm_gateway.py
+++ b/API/app/services/llm_gateway.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 import json
 import os
+import asyncio
 from typing import Any, Dict, List, Optional
 
 from openai import OpenAI
@@ -74,4 +75,5 @@ def run_llm(messages: List[Dict[str, str]]) -> str:
 
 # chat.py는 async call_llm(...)을 호출하므로 간단 래퍼 제공
 async def call_llm(messages: List[Dict[str, str]]) -> str:
-    return run_llm(messages)
+    """Run the blocking LLM call in a thread to avoid blocking the event loop."""
+    return await asyncio.to_thread(run_llm, messages)

--- a/API/app/services/stage.py
+++ b/API/app/services/stage.py
@@ -1,4 +1,5 @@
 import logging
+import asyncio
 from typing import Any, Dict, List, Optional, Tuple
 
 from fastapi import UploadFile
@@ -16,7 +17,8 @@ logger = logging.getLogger(__name__)
 
 
 async def _classify(user_text: str, attachment_ids: Optional[List[str]]) -> Tuple[Mode, Dict[str, Any], bool]:
-    decision = classify_with_llm(user_text, attachment_ids or [])
+    """Run the classification LLM in a thread so it doesn't block the event loop."""
+    decision = await asyncio.to_thread(classify_with_llm, user_text, attachment_ids or [])
     mode: Mode = decision.flow
     entities: Dict[str, Any] = decision.entities or {}
     use_retrieval: bool = bool(getattr(decision, "use_retrieval", False))


### PR DESCRIPTION
## Summary
- prevent ask processing from blocking the event loop by running LLM calls in background threads
- offload classifier and answerer LLM requests using `asyncio.to_thread`

## Testing
- `pytest API`


------
https://chatgpt.com/codex/tasks/task_b_68a69962ef488323a4b3a00417799265